### PR TITLE
Removed dependabot from ignore list of build-snapshot workflow

### DIFF
--- a/.github/workflows/build-snapshot.yml
+++ b/.github/workflows/build-snapshot.yml
@@ -5,7 +5,6 @@ on:
     branches-ignore:
       - master
       - version-*
-      - dependabot**
     paths-ignore:
       - README.md
 

--- a/.github/workflows/ci-unwelcome-words.yml
+++ b/.github/workflows/ci-unwelcome-words.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v4
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gradle:8.11.1-jdk11 AS build
+FROM gradle:8.11.1-jdk21 AS build
 ARG app_version=0.0.0
 COPY ./ .
 RUN gradle --no-daemon clean build dockerPrepare -Prelease_version=${release_version}


### PR DESCRIPTION
* dependabot doesn't run ci-unwelcome-words workflow
* use JDK 21 for build